### PR TITLE
feat: Implement pounce phase logic and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "dev": "nodemon index.js",
+    "start": "node quiz-app/server/index.js",
+    "dev": "nodemon quiz-app/server/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/quiz-app/client/host.html
+++ b/quiz-app/client/host.html
@@ -10,13 +10,28 @@
     <h1>Quizmaster Controls</h1>
     <div id="host-status-display">Initializing Quizmaster controls...</div>
 
-    <div>
-        <button id="start-question-btn">Next Question / Start Question</button>
-        <button id="pounce-start-btn">Start Pounce Phase</button>
-        <button id="bounce-start-btn">Start Bounce Phase</button>
+    <div class="quiz-control-section">
+        <button id="start-quiz-btn">Start Quiz</button>
+        <button id="end-quiz-btn" disabled>End Quiz</button>
     </div>
 
-    <div id="current-question-info">Question: Not Started - Phase: None</div>
+    <div class="question-control-section">
+        <button id="start-question-btn" disabled>Next Question</button>
+        <button id="pounce-start-btn" disabled>Start Pounce Phase</button>
+        <button id="bounce-start-btn" disabled>Start Bounce Phase</button>
+    </div>
+
+    <div id="current-question-info">Quiz Status: Not Started</div>
+
+    <div id="player-scores-container">
+        <h3>Player Scores:</h3>
+        <p>No players have joined yet.</p>
+    </div>
+
+    <div id="pounce-submissions-container">
+        <h3>Pounce Submissions:</h3>
+        <p>No pounce answers yet for this question, or pounce phase not active.</p>
+    </div>
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="/host.js"></script>

--- a/quiz-app/client/index.html
+++ b/quiz-app/client/index.html
@@ -38,7 +38,17 @@
     <div id="quiz-interface-section" class="hidden"> <!-- Initially hidden -->
         <h1>Quiz Player View</h1>
         <div id="status-display">Connecting to server...</div>
+        <div id="player-score-display">Score: 0</div>
         <div id="question-display">Waiting for quiz to start...</div>
+
+        <div id="pounce-section" class="hidden">
+            <button id="pounce-btn">Pounce!</button>
+            <div id="pounce-timer-display"></div>
+            <div id="pounce-answer-section" class="hidden">
+                <input type="text" id="pounce-answer-input" placeholder="Your answer...">
+                <button id="submit-pounce-answer-btn">Submit Answer</button>
+            </div>
+        </div>
         <!-- Player interaction elements will go here later -->
     </div>
 

--- a/quiz-app/client/script.js
+++ b/quiz-app/client/script.js
@@ -17,6 +17,19 @@ let joinQuizBtn;
 let playerErrorDiv;
 let entrySection;
 let quizInterfaceSection;
+let playerScoreDisplay; // For displaying player's score
+
+// Pounce UI elements
+let pounceButton;
+let pounceAnswerSection;
+let pounceAnswerInput;
+let submitPounceAnswerBtn;
+let pounceTimerDisplay;
+
+// Player state
+let currentPlayerId = null;
+let pounceDecisionTimer = null;
+let pounceAnswerTimer = null;
 
 document.addEventListener('DOMContentLoaded', () => {
   // Quizmaster login elements
@@ -37,6 +50,14 @@ document.addEventListener('DOMContentLoaded', () => {
   // Quiz interface display elements (player view)
   statusDisplay = document.getElementById('status-display');
   questionDisplay = document.getElementById('question-display');
+  playerScoreDisplay = document.getElementById('player-score-display');
+
+  // Pounce UI elements
+  pounceButton = document.getElementById('pounce-btn');
+  pounceAnswerSection = document.getElementById('pounce-answer-section');
+  pounceAnswerInput = document.getElementById('pounce-answer-input');
+  submitPounceAnswerBtn = document.getElementById('submit-pounce-answer-btn');
+  pounceTimerDisplay = document.getElementById('pounce-timer-display');
 
   console.log('DOM fully loaded and parsed. UI elements selected.');
 
@@ -84,10 +105,30 @@ document.addEventListener('DOMContentLoaded', () => {
       //    updateStatus(`Joined quiz as ${playerName}. Waiting for question...`);
       // 3. On failure:
       //    playerErrorDiv.textContent = "Failed to join quiz (e.g., invalid code, name taken)";
-      alert(`Player join functionality for ${playerName} (code: ${quizCode}) is not fully implemented yet!`);
+      // alert(`Player join functionality for ${playerName} (code: ${quizCode}) is not fully implemented yet!`);
+
+      // Connect socket and then emit join-quiz
+      if (socket && !socket.connected) {
+        socket.once('connect', () => {
+          console.log('Socket connected, emitting join-quiz.');
+          socket.emit('join-quiz', playerName); // Sending only playerName as per new spec
+        });
+        initializePlayerSocket(); // This calls socket.connect()
+      } else if (socket && socket.connected) {
+        console.log('Socket already connected, emitting join-quiz.');
+        socket.emit('join-quiz', playerName);
+      }
     });
   } else {
     console.warn('Player join button not found.');
+  }
+
+  if (pounceButton) {
+    pounceButton.addEventListener('click', handlePounceButtonClick);
+  }
+
+  if (submitPounceAnswerBtn) {
+    submitPounceAnswerBtn.addEventListener('click', handleSubmitPounceAnswer);
   }
 
   // Initial status update for player view (if it were visible)
@@ -95,6 +136,60 @@ document.addEventListener('DOMContentLoaded', () => {
     updateStatus("Initializing client...");
   }
 });
+
+function clearPounceTimers() {
+  if (pounceDecisionTimer) {
+    clearTimeout(pounceDecisionTimer);
+    pounceDecisionTimer = null;
+  }
+  if (pounceAnswerTimer) {
+    clearTimeout(pounceAnswerTimer);
+    pounceAnswerTimer = null;
+  }
+}
+
+function handlePounceButtonClick() {
+  if (!pounceButton || !pounceAnswerSection || !pounceTimerDisplay) return;
+
+  pounceButton.disabled = true;
+  pounceButton.classList.add('hidden'); // Or change text: pounceButton.textContent = "Pounced!";
+  clearPounceTimers(); // Clear the initial pounce decision timer
+
+  pounceAnswerSection.classList.remove('hidden');
+  if(pounceAnswerInput) pounceAnswerInput.focus();
+  if(pounceTimerDisplay) pounceTimerDisplay.textContent = "Time to answer: 15s"; // Example
+
+  let answerTimeRemaining = 15; // 15 seconds for answering
+  pounceAnswerTimer = setInterval(() => {
+    answerTimeRemaining--;
+    if(pounceTimerDisplay) pounceTimerDisplay.textContent = `Time to answer: ${answerTimeRemaining}s`;
+    if (answerTimeRemaining <= 0) {
+      clearPounceTimers();
+      if(pounceTimerDisplay) pounceTimerDisplay.textContent = "Time's up!";
+      pounceAnswerSection.classList.add('hidden');
+      if(pounceButton && !pounceButton.classList.contains('hidden')) { // If pounce button was re-shown by mistake
+          pounceButton.classList.add('hidden');
+      }
+    }
+  }, 1000);
+}
+
+function handleSubmitPounceAnswer() {
+  if (!pounceAnswerInput || !pounceAnswerSection) return;
+
+  const answer = pounceAnswerInput.value.trim();
+  if (answer) {
+    socket.emit('submit-pounce-answer', { answer });
+    pounceAnswerInput.value = ''; // Clear input
+  }
+  pounceAnswerSection.classList.add('hidden');
+  clearPounceTimers();
+  if(pounceTimerDisplay) pounceTimerDisplay.textContent = ""; // Clear timer display
+  if(pounceButton && !pounceButton.classList.contains('hidden')) { // Hide pounce button if it wasn't already
+      pounceButton.classList.add('hidden');
+  }
+}
+
 
 function updateStatus(message) {
   if (statusDisplay) {
@@ -128,40 +223,38 @@ try {
   socket = io({ autoConnect: false }); // Prevent auto-connection
   console.log('Socket.IO client initialized but not auto-connecting.');
 
-  // Call this function after player successfully joins
+  // Call this function after player clicks "Join Quiz"
   function initializePlayerSocket() {
     if (socket && !socket.connected) {
-      socket.connect();
+      socket.connect(); // Manually connect
       console.log('Socket.IO connection initiated for player.');
     }
   }
 
-  // Example: To be called after player clicks "Join Quiz" and server confirms
-  // For now, let's connect if the quiz interface is shown (e.g. for testing direct access without login)
-  // This is a temporary measure for development. Proper flow would be:
-  // 1. User fills join form.
-  // 2. Clicks "Join".
-  // 3. Client emits "join-request" (or similar) to server with details.
-  // 4. Server validates, then replies with "join-success" or "join-failed".
-  // 5. On "join-success", client calls initializePlayerSocket(), hides entry, shows quiz interface.
-
-  // TEMPORARY: If quiz interface is visible (e.g. no login screen for testing), connect immediately.
-  // This assumes that if quiz-interface-section is visible, we are a player.
-  // This is NOT the final logic for joining.
-  if (quizInterfaceSection && !quizInterfaceSection.classList.contains('hidden')) {
-      console.log("Quiz interface is visible on load, attempting to connect socket for player.");
-      initializePlayerSocket();
-  }
-  // The joinQuizBtn event listener above should call initializePlayerSocket()
-  // and then hide entrySection and show quizInterfaceSection upon successful join.
-
-
   socket.on('connect', () => {
     console.log('Player connected to server via Socket.IO. Socket ID:', socket.id);
+    // Note: 'join-quiz' is emitted after connection in the joinQuizBtn listener
     if (document.readyState === "loading") {
-        document.addEventListener('DOMContentLoaded', () => updateStatus('Connected. Waiting for quiz...'));
+        document.addEventListener('DOMContentLoaded', () => updateStatus('Connected. Ready to join...'));
     } else {
-        updateStatus('Connected. Waiting for quiz...');
+        updateStatus('Connected. Ready to join...');
+    }
+  });
+
+  socket.on('join-success', (data) => {
+    console.log('Successfully joined quiz:', data);
+    currentPlayerId = data.playerId;
+    if (entrySection) entrySection.classList.add('hidden');
+    if (quizInterfaceSection) quizInterfaceSection.classList.remove('hidden');
+    handleQuizStateUpdate(data.quizState); // Initial state update
+  });
+
+  socket.on('join-failed', (message) => {
+    console.error('Failed to join quiz:', message);
+    if (playerErrorDiv) playerErrorDiv.textContent = message;
+    // Ensure socket is disconnected if join fails and we initiated a connect
+    if (socket && socket.connected) {
+        socket.disconnect();
     }
   });
 
@@ -176,8 +269,10 @@ try {
 
   socket.on('quizStateUpdate', (state) => {
     console.log('Player received quizStateUpdate:', state);
-    if (!statusDisplay || !questionDisplay) {
-      console.warn('quizStateUpdate: UI elements not ready yet for player.');
+    // DOM elements might not be ready if this is the first state update after join-success
+    // Deferring with a microtask or ensuring DOMContentLoaded has run for all queried elements.
+    if (!statusDisplay || !questionDisplay || !pounceButton || !pounceAnswerSection || !pounceTimerDisplay || !playerScoreDisplay) {
+      console.warn('quizStateUpdate: UI elements not fully ready. Retrying once DOM is loaded.');
       document.addEventListener('DOMContentLoaded', () => handleQuizStateUpdate(state));
       return;
     }
@@ -185,78 +280,84 @@ try {
   });
 
   function handleQuizStateUpdate(state) {
-    if (state) {
-      updateQuestionInfo(state.currentQuestionIndex, state.currentPhase);
-      if (state.currentPhase === 'pounce') {
-        updateStatus('Pounce phase!');
+    if (!state) {
+      console.error('Player received empty state in quizStateUpdate');
+      return;
+    }
+
+    updateQuestionInfo(state.currentQuestionIndex, state.currentPhase);
+
+    // Update score display
+    if (playerScoreDisplay && state.players && currentPlayerId && state.players[currentPlayerId]) {
+      playerScoreDisplay.textContent = `Score: ${state.players[currentPlayerId].score}`;
+    } else if (playerScoreDisplay) {
+      playerScoreDisplay.textContent = "Score: N/A";
+    }
+
+    // Pounce UI logic
+    clearPounceTimers(); // Clear any existing pounce timers
+
+    if (state.currentPhase === 'pounce') {
+      updateStatus('Pounce phase! Click "Pounce" to answer.');
+      if (pounceButton) {
+        pounceButton.classList.remove('hidden');
+        pounceButton.disabled = false;
+      }
+      if (pounceAnswerSection) pounceAnswerSection.classList.add('hidden'); // Hide answer input initially
+      if (pounceTimerDisplay) {
+        pounceTimerDisplay.classList.remove('hidden');
+        pounceTimerDisplay.textContent = "Pounce open for: 10s"; // Example
+      }
+
+      let pounceTimeRemaining = 10; // 10 seconds to click "Pounce"
+      pounceDecisionTimer = setInterval(() => {
+        pounceTimeRemaining--;
+        if(pounceTimerDisplay) pounceTimerDisplay.textContent = `Pounce open for: ${pounceTimeRemaining}s`;
+        if (pounceTimeRemaining <= 0) {
+          clearPounceTimers();
+          if(pounceTimerDisplay) pounceTimerDisplay.textContent = "Pounce closed.";
+          if(pounceButton) {
+            pounceButton.classList.add('hidden');
+            pounceButton.disabled = true;
+          }
+        }
+      }, 1000);
+
+    } else { // Not pounce phase
+      if (pounceButton) pounceButton.classList.add('hidden');
+      if (pounceAnswerSection) pounceAnswerSection.classList.add('hidden');
+      if (pounceTimerDisplay) pounceTimerDisplay.classList.add('hidden');
+
+      // General status updates based on phase
+      if (state.currentQuestionIndex === -1) {
+        updateStatus('Waiting for quiz to start...');
       } else if (state.currentPhase === 'bounce') {
         updateStatus('Bounce phase!');
-      } else if (state.currentQuestionIndex === -1) {
-        updateStatus('Waiting for quiz to start...');
-      } else if (state.currentQuestionIndex > -1 && state.currentPhase !== 'pounce' && state.currentPhase !== 'bounce') {
+      } else if (state.currentPhase === 'answer') {
+         updateStatus('Answer reveal phase.');
+      } else if (state.currentPhase === 'question' || !state.currentPhase ) { // question or undefined phase after question start
         updateStatus(`Question ${state.currentQuestionIndex + 1} active.`);
+      } else if (state.currentPhase === 'finished') {
+        updateStatus('Quiz has finished!');
       }
-    } else {
-      console.error('Player received empty state in quizStateUpdate');
     }
   }
 
-  socket.on('new-question', (data) => {
-    console.log('Player received new-question event:', data);
-    if (!statusDisplay || !questionDisplay) {
-      console.warn('new-question: UI elements not ready yet for player.');
-      document.addEventListener('DOMContentLoaded', () => handleNewQuestion(data));
-      return;
+  // Remove specific handlers if quizStateUpdate covers them fully
+  // socket.on('new-question', ...) - Covered by quizStateUpdate
+  // socket.on('pounce-started', ...) - Covered by quizStateUpdate
+  // socket.on('bounce-started', ...) - Covered by quizStateUpdate
+
+  socket.on('pounce-submission-ack', ({ success }) => {
+    if (success) {
+      updateStatus('Pounce answer submitted successfully!');
+      // Optionally, provide more visual feedback
+    } else {
+      updateStatus('Failed to submit pounce answer.');
+      // Optionally, allow retry or show error
     }
-    handleNewQuestion(data);
   });
 
-  function handleNewQuestion(data) {
-    if (data && typeof data.currentQuestionIndex !== 'undefined') {
-      updateQuestionInfo(data.currentQuestionIndex, data.phase || 'question');
-      updateStatus(`Question ${data.currentQuestionIndex + 1} started.`);
-    } else {
-      console.error('Player received invalid data for new-question:', data);
-    }
-  }
-
-  socket.on('pounce-started', (data) => {
-    console.log('Player received pounce-started event:', data);
-    if (!statusDisplay || !questionDisplay) {
-      console.warn('pounce-started: UI elements not ready yet for player.');
-      document.addEventListener('DOMContentLoaded', () => handlePounceStarted(data));
-      return;
-    }
-    handlePounceStarted(data);
-  });
-
-  function handlePounceStarted(data) {
-    if (data && data.phase === 'pounce') {
-      updateQuestionInfo(null, data.phase); // Update phase display
-      updateStatus('Pounce phase has started! Get ready!');
-    } else {
-      console.error('Player received invalid data for pounce-started:', data);
-    }
-  }
-
-  socket.on('bounce-started', (data) => {
-    console.log('Player received bounce-started event:', data);
-    if (!statusDisplay || !questionDisplay) {
-      console.warn('bounce-started: UI elements not ready yet for player.');
-      document.addEventListener('DOMContentLoaded', () => handleBounceStarted(data));
-      return;
-    }
-    handleBounceStarted(data);
-  });
-
-  function handleBounceStarted(data) {
-    if (data && data.phase === 'bounce') {
-      updateQuestionInfo(null, data.phase); // Update phase display
-      updateStatus('Bounce phase has started! Get ready!');
-    } else {
-      console.error('Player received invalid data for bounce-started:', data);
-    }
-  }
 
 } catch (error) {
   console.error("Player Socket.IO connection error:", error);

--- a/quiz-app/client/style.css
+++ b/quiz-app/client/style.css
@@ -1,0 +1,236 @@
+/* Basic reset and layout */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #f4f4f4;
+    padding: 20px;
+}
+
+h1, h2, h3 {
+    margin-bottom: 15px;
+    color: #2c3e50;
+}
+
+h1 {
+    text-align: center;
+    font-size: 2.5em;
+    margin-bottom: 30px;
+}
+
+/* Section containers */
+.section {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.quiz-control-section, .question-control-section {
+    background: white;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 15px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+/* Button styling */
+button {
+    background: #3498db;
+    color: white;
+    border: none;
+    padding: 12px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    margin: 5px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover:not(:disabled) {
+    background: #2980b9;
+}
+
+button:disabled {
+    background: #bdc3c7;
+    cursor: not-allowed;
+}
+
+/* Specific button colors */
+#start-quiz-btn {
+    background: #27ae60;
+}
+
+#start-quiz-btn:hover:not(:disabled) {
+    background: #229954;
+}
+
+#end-quiz-btn {
+    background: #e74c3c;
+}
+
+#end-quiz-btn:hover:not(:disabled) {
+    background: #c0392b;
+}
+
+#pounce-start-btn, #pounce-btn {
+    background: #f39c12;
+}
+
+#pounce-start-btn:hover:not(:disabled), #pounce-btn:hover:not(:disabled) {
+    background: #e67e22;
+}
+
+.correct-btn {
+    background: #27ae60 !important;
+}
+
+.correct-btn:hover:not(:disabled) {
+    background: #229954 !important;
+}
+
+.incorrect-btn {
+    background: #e74c3c !important;
+}
+
+.incorrect-btn:hover:not(:disabled) {
+    background: #c0392b !important;
+}
+
+/* Input styling */
+input[type="text"], input[type="password"] {
+    width: 100%;
+    padding: 12px;
+    border: 2px solid #ddd;
+    border-radius: 5px;
+    font-size: 16px;
+    margin-bottom: 10px;
+}
+
+input[type="text"]:focus, input[type="password"]:focus {
+    outline: none;
+    border-color: #3498db;
+}
+
+/* Status displays */
+#host-status-display, #status-display {
+    background: #ecf0f1;
+    padding: 15px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+    border-left: 4px solid #3498db;
+    font-weight: bold;
+}
+
+#current-question-info, #question-display {
+    background: #e8f5e8;
+    padding: 15px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+    border-left: 4px solid #27ae60;
+    font-weight: bold;
+    font-size: 18px;
+}
+
+#player-score-display {
+    background: #fff3cd;
+    padding: 10px 15px;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    border-left: 4px solid #f39c12;
+    font-weight: bold;
+}
+
+/* Player scores container */
+#player-scores-container {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+#player-scores-container ul {
+    list-style: none;
+}
+
+#player-scores-container li {
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+    font-weight: bold;
+}
+
+#player-scores-container li:last-child {
+    border-bottom: none;
+}
+
+/* Pounce submissions */
+#pounce-submissions-container {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.pounce-submission {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+    padding: 15px;
+    margin-bottom: 10px;
+}
+
+.pounce-submission p {
+    margin-bottom: 10px;
+}
+
+/* Pounce section styling */
+#pounce-section {
+    background: #fff3cd;
+    border: 2px solid #f39c12;
+    border-radius: 8px;
+    padding: 20px;
+    margin: 20px 0;
+    text-align: center;
+}
+
+#pounce-answer-section {
+    margin-top: 15px;
+    padding: 15px;
+    background: white;
+    border-radius: 5px;
+}
+
+#pounce-answer-input {
+    margin-bottom: 10px;
+}
+
+#pounce-timer-display {
+    font-size: 18px;
+    font-weight: bold;
+    color: #e67e22;
+    margin: 10px 0;
+}
+
+/* Utility classes */
+.hidden {
+    display: none !important;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.error-text {
+    color: #e74c3c;
+    font-weight: bold;
+    margin-top: 10px;
+}

--- a/quiz-app/server/index.js
+++ b/quiz-app/server/index.js
@@ -3,7 +3,16 @@ const http = require('http');
 const socketIo = require('socket.io');
 const path = require('path'); // Added for serving client files
 
-const { quizState, incrementQuestion, setPhase, getQuizState } = require('./state');
+const {
+  quizState,
+  incrementQuestion,
+  setPhase,
+  getQuizState,
+  addPlayer,
+  updateScore,
+  recordPounceAnswer,
+  clearPounceAnswers,
+} = require('./state');
 
 const app = express();
 const server = http.createServer(app);
@@ -30,46 +39,78 @@ io.on('connection', (socket) => {
   // Send current quiz state to newly connected client
   socket.emit('quizStateUpdate', getQuizState());
 
+  socket.on('join-quiz', (playerName) => {
+    addPlayer(socket.id, playerName);
+    const updatedState = getQuizState();
+    socket.emit('join-success', { playerId: socket.id, quizState: updatedState });
+    io.emit('quizStateUpdate', updatedState);
+    console.log(`Player ${playerName} (ID: ${socket.id}) joined the quiz.`);
+  });
+
   socket.on('disconnect', () => {
     console.log(`Client disconnected: ${socket.id}`);
+    // Future enhancement: remove player from quizState.players if they disconnect
+    // delete quizState.players[socket.id];
+    // io.emit('quizStateUpdate', getQuizState()); // Notify others
   });
 
   // Quizmaster action handlers
   socket.on('start-question', () => {
     incrementQuestion();
+    clearPounceAnswers(); // Clear pounce answers for the new question
     // Assuming questions are loaded elsewhere and incrementQuestion updates index correctly
     // We might also want to reset phase here, e.g., setPhase('question_active');
-    // For now, just incrementing and sending new index.
     const updatedState = getQuizState();
     console.log(`Quizmaster started new question: ${updatedState.currentQuestionIndex}`);
-    io.emit('new-question', { currentQuestionIndex: updatedState.currentQuestionIndex, phase: updatedState.currentPhase });
-    // It's often better to send the whole state:
-    // io.emit('quizStateUpdate', updatedState);
+    io.emit('quizStateUpdate', updatedState); // Send the whole state
   });
 
   socket.on('pounce-start', () => {
     setPhase('pounce');
     const updatedState = getQuizState();
     console.log('Quizmaster initiated pounce phase.');
-    io.emit('pounce-started', { phase: updatedState.currentPhase });
-    // Or send the whole state:
-    // io.emit('quizStateUpdate', updatedState);
+    io.emit('quizStateUpdate', updatedState); // Send the whole state
   });
 
   socket.on('bounce-start', () => {
     setPhase('bounce');
     const updatedState = getQuizState();
     console.log('Quizmaster initiated bounce phase.');
-    io.emit('bounce-started', { phase: updatedState.currentPhase });
-    // Or send the whole state:
-    // io.emit('quizStateUpdate', updatedState);
+    io.emit('quizStateUpdate', updatedState); // Send the whole state
   });
 
-  // Placeholder for player action handlers (e.g., submitting answers)
-  // socket.on('submitAnswer', (answer) => {
-  //   console.log(`Player ${socket.id} submitted answer: ${answer}`);
-  //   // Logic to handle player answers
-  // });
+  // Player action handlers
+  socket.on('submit-pounce-answer', ({ answer }) => {
+    const playerId = socket.id;
+    recordPounceAnswer(playerId, answer);
+    const player = getQuizState().players[playerId];
+    const playerName = player ? player.name : 'Unknown Player';
+
+    console.log(`Player ${playerName} (ID: ${playerId}) submitted pounce answer: ${answer}`);
+
+    // Notify quizmaster (and potentially other players or just the quizmaster UI)
+    io.emit('pounce-answer-received', {
+      playerId: playerId,
+      playerName: playerName,
+      answer: answer,
+    });
+
+    // Acknowledge receipt to the player
+    socket.emit('pounce-submission-ack', { success: true });
+  });
+
+  // Quizmaster evaluating pounce answers
+  socket.on('evaluate-pounce-answer', ({ playerId, isCorrect }) => {
+    const points = isCorrect ? 10 : -10;
+    updateScore(playerId, points);
+    const updatedState = getQuizState();
+    io.emit('quizStateUpdate', updatedState);
+    console.log(`Pounce answer for ${playerId} evaluated as ${isCorrect ? 'correct' : 'incorrect'}. Score updated.`);
+
+    // Optionally, notify the specific player and quizmaster
+    // io.to(playerId).emit('pounce-answer-evaluated', { isCorrect, score: updatedState.players[playerId]?.score });
+    // socket.emit('pounce-evaluation-ack', { playerId, status: 'evaluated' }); // Ack to quizmaster
+  });
 });
 
 server.listen(PORT, () => {

--- a/quiz-app/server/state.js
+++ b/quiz-app/server/state.js
@@ -1,8 +1,38 @@
 const quizState = {
   currentQuestionIndex: -1,
   currentPhase: null, // Possible phases: 'question', 'answer', 'finished'
+  players: {},
+  pounceAnswers: {},
   // More state properties will be added later (e.g., scores, questions)
 };
+
+function addPlayer(playerId, playerName) {
+  if (quizState.players[playerId]) {
+    console.log(`Player with ID ${playerId} already exists.`);
+  } else {
+    quizState.players[playerId] = {
+      id: playerId,
+      name: playerName,
+      score: 0,
+    };
+  }
+}
+
+function updateScore(playerId, points) {
+  if (quizState.players[playerId]) {
+    quizState.players[playerId].score += points;
+  } else {
+    console.log(`Player with ID ${playerId} not found.`);
+  }
+}
+
+function recordPounceAnswer(playerId, answer) {
+  quizState.pounceAnswers[playerId] = answer;
+}
+
+function clearPounceAnswers() {
+  quizState.pounceAnswers = {};
+}
 
 function incrementQuestion() {
   quizState.currentQuestionIndex++;
@@ -15,7 +45,11 @@ function setPhase(phase) {
 
 // Function to get the current state (optional, but can be useful)
 function getQuizState() {
-  return { ...quizState }; // Return a copy to prevent direct modification
+  return {
+    ...quizState,
+    players: { ...quizState.players },
+    pounceAnswers: { ...quizState.pounceAnswers },
+  }; // Return a copy to prevent direct modification
 }
 
 module.exports = {
@@ -23,4 +57,8 @@ module.exports = {
   incrementQuestion,
   setPhase,
   getQuizState,
+  addPlayer,
+  updateScore,
+  recordPounceAnswer,
+  clearPounceAnswers,
 };

--- a/quiz-app/server/state.js
+++ b/quiz-app/server/state.js
@@ -1,6 +1,7 @@
 const quizState = {
   currentQuestionIndex: -1,
-  currentPhase: null, // Possible phases: 'question', 'answer', 'finished'
+  currentPhase: null, // Possible phases: 'question', 'pounce', 'bounce', 'answer'
+  quizStatus: 'not_started', // Possible statuses: 'not_started', 'active', 'finished'
   players: {},
   pounceAnswers: {},
   // More state properties will be added later (e.g., scores, questions)
@@ -36,11 +37,37 @@ function clearPounceAnswers() {
 
 function incrementQuestion() {
   quizState.currentQuestionIndex++;
+  quizState.currentPhase = 'question'; // Reset phase when starting a new question
   // Potentially add logic here to check if quiz is over
 }
 
 function setPhase(phase) {
   quizState.currentPhase = phase;
+}
+
+function startQuiz() {
+  quizState.quizStatus = 'active';
+  quizState.currentQuestionIndex = -1; // Reset to -1, will be incremented when first question starts
+  quizState.currentPhase = null;
+  quizState.pounceAnswers = {};
+  // Don't reset players and scores - they should persist
+  console.log('Quiz started successfully');
+}
+
+function endQuiz() {
+  quizState.quizStatus = 'finished';
+  quizState.currentPhase = 'finished';
+  quizState.pounceAnswers = {};
+  console.log('Quiz ended successfully');
+}
+
+function resetQuiz() {
+  quizState.currentQuestionIndex = -1;
+  quizState.currentPhase = null;
+  quizState.quizStatus = 'not_started';
+  quizState.players = {};
+  quizState.pounceAnswers = {};
+  console.log('Quiz reset successfully');
 }
 
 // Function to get the current state (optional, but can be useful)
@@ -61,4 +88,7 @@ module.exports = {
   updateScore,
   recordPounceAnswer,
   clearPounceAnswers,
+  startQuiz,
+  endQuiz,
+  resetQuiz,
 };


### PR DESCRIPTION
This commit introduces the server-side and client-side functionality for the pounce phase of the quiz.

Key changes include:

Server-Side (`server/index.js`, `server/state.js`):
- Added player management to `state.js`, including adding players and tracking scores.
- Implemented storage for pounce answers in `state.js`.
- Added Socket.IO event handlers in `index.js` for:
  - `join-quiz`: Allows players to join the quiz.
  - `submit-pounce-answer`: Receives pounce answers from players.
  - `evaluate-pounce-answer`: Allows quizmaster to mark pounce answers as correct (+10 points) or incorrect (-10 points).
- Ensured player scores and pounce answers are part of the `quizStateUpdate` broadcast.
- Pounce answers are cleared at the start of each new question.

Client-Side (Player: `client/index.html`, `client/script.js`):
- Updated `index.html` with UI elements for pounce button, answer input, submission button, timers, and score display.
- Implemented logic in `script.js` for:
  - Joining the quiz and displaying player-specific information.
  - Displaying a "Pounce" button and a 10s timer when the pounce phase starts.
  - Allowing answer submission within a subsequent 15s timer if you pounce.
  - Sending the pounce answer to the server.
  - Displaying your score, updated in real-time.

Client-Side (Quizmaster: `client/host.html`, `client/host.js`):
- Updated `host.html` with containers to display pounce submissions and all player scores.
- Implemented logic in `host.js` for:
  - Receiving and displaying pounce answers submitted by players in real-time.
  - Providing "Correct" and "Incorrect" buttons for each pounce answer.
  - Sending the evaluation of each pounce answer to the server.
  - Displaying a continuously updated list of all players and their scores.

This implementation fulfills the PRD requirements for the pounce mechanic, including real-time updates and scoring.